### PR TITLE
upgrade base image to python:3.9.16-alpine3.17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Globals and input args
-FROM python:3.9.15-alpine
+FROM python:3.9.16-alpine3.17
 WORKDIR /app
 
 # Prepare our app requirements and install it...


### PR DESCRIPTION
Hi,

I think it would be good to upgrade to python:3.9.16-alpine3.17 of the base image as it fixes some vulnerabilities.

Thank you