### PR TITLE
add option to ignore all volumes that are not annotated

### DIFF
--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -40,6 +40,8 @@ verbose: "false"
 victoriametrics_mode: "false"
 # Auth header for mimir or cortex
 scope_orgid_auth_header: ""
+# Ignore non annotated pvcs
+ignore_unless_annotated: "false"
 
 
 # Pretty much ignore anything below here I'd say, unless you really know what you're doing.  :)
@@ -123,6 +125,10 @@ globalEnvs:
   # If you are using Cortex or Mimir you'll probably need to set an scope OrgID auth header for it
   - name: SCOPE_ORGID_AUTH_HEADER
     value: "{{ .Values.scope_orgid_auth_header }}"
+
+  # Ignore volumes that are not annotated with volume.autoscaler.kubernetes.io/ignore: "false"
+  - name: IGNORE_UNLESS_ANNOTATED
+    value: "{{ .Values.ignore_unless_annotated }}"
 
 
 # Additional pod annotations

--- a/main.py
+++ b/main.py
@@ -201,7 +201,7 @@ if __name__ == "__main__":
 
                 # Check if we set on this PV we want to ignore the volume autoscaler
                 if pvcs_in_kubernetes[volume_description]['ignore']:
-                    print("  IGNORING scaling this because the ignore annotation was set to true")
+                    print("  IGNORING scaling this because the ignore annotation was set to true or ignore_unless_annotated is set to true and pvc does not have ignore=false")
                     print("=============================================================================================================")
                     continue
 


### PR DESCRIPTION
Adds a setting to allow ignoring all pvc's that do not have the annotation ```volume.autoscaler.kubernetes.io/ignore: "false"```

This allows volume autoscaling on only the pvc's you want while ignoring other non-tagged pvc's and is useful for large environment where you only want autoscaling on a small number of volumes or if you need to transition storageclasses to expandable types, in which case any old volumes will not become expandable and must be replaced and the data transferred to the new volume.

This makes it much easier to get new volumes in place while you perform the volume transition in large environments.


The default is false so that the autoscaler will work as it has previously.

HOW IT WORKS:

set IGNORE_UNLESS_ANNOTATED = "true" in the chart

all volumes are ignored except the volumes you exclusively annotate with ```volume.autoscaler.kubernetes.io/ignore: "false"```

!!!!!!!!!!!!MORE TESTING IS NEEDED TO HELP ENSURE FUNCTIONALITY IS WORKING AS EXPECTED!!!!!!!!!!!